### PR TITLE
fix naming errors on py3.8.3 @fedora32

### DIFF
--- a/junipervpn/tncc.py
+++ b/junipervpn/tncc.py
@@ -573,7 +573,7 @@ class TNCCServer:
         self.tncc = t
 
     def process_cmd(self):
-        buf = sock.recv(1024).decode('ascii')
+        buf = self.sock.recv(1024).decode('ascii')
         if not buf:
             sys.exit(0)
         cmd, buf = buf.split('\n', 1)
@@ -587,7 +587,7 @@ class TNCCServer:
         if cmd == 'start':
             cookie = self.tncc.get_cookie(args['Cookie'], args['DSSIGNIN'])
             resp = '200\n3\n%s\n\n' % cookie.value
-            sock.send(resp.encode('ascii'))
+            self.sock.send(resp.encode('ascii'))
         elif cmd == 'setcookie':
             # FIXME: Support for periodic updates
             dsid_value = args['Cookie']

--- a/junipervpn/tncc.py
+++ b/junipervpn/tncc.py
@@ -16,7 +16,7 @@ import socket
 import urllib.request
 import urllib.error
 import urllib.parse
-import platform
+import platform as platform_py
 import json
 import datetime
 import xml.etree.ElementTree
@@ -599,7 +599,7 @@ def main():
 
     funk = 'TNCC_FUNK' in os.environ and os.environ['TNCC_FUNK'] != '0'
 
-    platform = os.environ.get('TNCC_PLATFORM', platform.system() + ' ' + platform.release())
+    platform = os.environ.get('TNCC_PLATFORM', platform_py.system() + ' ' + platform_py.release())
 
     if 'TNCC_HWADDR' in os.environ:
         mac_addrs = [n.strip() for n in os.environ['TNCC_HWADDR'].split(',')]


### PR DESCRIPTION
Doesn't work with my VPN afterwards, but these are obviously bugs, so fixing them doesn't hurt