### PR TITLE
junipervpn: config: do not turn string values to lowercase

### DIFF
--- a/junipervpn/vpn.py
+++ b/junipervpn/vpn.py
@@ -361,7 +361,7 @@ def main():
         # Custom converters accessible as config.get<converter name>()
         converters = dict(
             shell_split=shlex.split,
-            str=str.lower,
+            str=str,
         )
 
         # Use the same canonical key name as ArgumentParser.set_defaults()


### PR DESCRIPTION
Turning values to lowercase leads "stdin=DSID=%DSID%" to be changed into
"stdin=dsid=%dsid%", which breaks the VPN in a non-obvious way.